### PR TITLE
remove arrow function

### DIFF
--- a/jobs.html
+++ b/jobs.html
@@ -18,7 +18,10 @@ $.getJSON('https://api.github.com/repos/f2etw/jobs/issues', function(jobs) {
                     <h3>${job.title}</h3>
                     <p>from ${job.created_at}</p>
                     <ul class="labels">
-                        ${job.labels.map((label) => `<li style="background:#${label.color};">${label.name}</li>`).join("\n")}
+                    ${job.labels.map(
+                        function(label){
+                            return `<li style="background:#${label.color};">${label.name}</li>`
+                        }).join("\n")}
                     </ul>
                 </a>
             </li>


### PR DESCRIPTION
Chrome doesn't support it yet.
solve #33
