### PR TITLE
Upgrade dependencies & fix typo in records yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: ruby
 rvm:
   - 2.1
-before_install: npm install -g grunt-cli
 install: gem install github-pages
 before_script: npm install
 script:
   - jekyll build
-  - grunt build
-  - gulp build
+  - npm start
 #  - diff -r _site build
 #  - diff -r _site export

--- a/_data/records/20170921-F2ERGBA.yml
+++ b/_data/records/20170921-F2ERGBA.yml
@@ -15,7 +15,7 @@ data:
       total: -372
       note:
 
-   - name: KKTIX
+    - name: KKTIX
       category: 入帳手續費
       unitPrice: 0
       number: 1

--- a/metalsmith.json
+++ b/metalsmith.json
@@ -3,7 +3,7 @@
     "metalsmith-markdown": {},
     "metalsmith-sass": {
       "outputStyle": "expanded",
-      "includePaths": ["src/_sass"]
+      "includePaths": ["_sass"]
     },
     "metalsmith-templates": {
       "engine": "swig",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "the website of f2e Taiwan community",
   "main": "build.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "grunt build && gulp build",
     "postinstall": "cp .githooks/* .git/hooks/. && chmod +x .git/hooks/*"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -20,16 +20,16 @@
     "metalsmith": "~1.0.1",
     "metalsmith-collections": "^0.6.0",
     "metalsmith-markdown": "~0.2.1",
-    "metalsmith-sass": "~0.5.0",
+    "metalsmith-sass": "^1.4.0",
     "metalsmith-templates": "~0.6.0",
     "swig": "~1.4.2"
   },
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-connect": "^0.9.0",
-    "grunt-contrib-copy": "^0.7.0",
-    "grunt-contrib-watch": "^0.6.1",
+    "grunt": "^1.0.1",
+    "grunt-contrib-clean": "^1.1.0",
+    "grunt-contrib-connect": "^1.0.2",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-watch": "^1.0.0",
     "grunt-matter": "^0.1.3",
     "grunt-metalsmith": "^1.0.0",
     "grunt-string-replace": "^1.0.0",
@@ -37,7 +37,7 @@
     "gulp-front-matter": "^1.0.0",
     "gulp-layoutize": "0.0.4",
     "gulp-marked": "^1.0.0",
-    "gulp-replace": "^0.5.0",
-    "gulp-sass": "^1.1.0"
+    "gulp-replace": "^0.6.1",
+    "gulp-sass": "^3.1.0"
   }
 }


### PR DESCRIPTION
- Fix the wrong indent in `_data/records/20170921-F2ERGBA.yml`.

- As the [built result](https://travis-ci.org/f2etw/f2etw.github.io/builds/298432365#L697), the lower version `node-sass` is unable to build on travis CI. Upgrade `gulp-sass` and `metalsmith-sass` to latest version for safety.

- Upgrade grunt to stable version.